### PR TITLE
style: ios 폰트 폴백 현상 fix

### DIFF
--- a/src/style/GlobalStyle.jsx
+++ b/src/style/GlobalStyle.jsx
@@ -6,7 +6,10 @@ export const GlobalStyle = createGlobalStyle`
         font-family: 'SUIT-Variable';
         font-style: normal;
         font-weight: 100 900;
-        src: url(${SUITVariable}) format('SUIT-Variable');
+        src:
+            local('SUIT Variable'),        
+            url(${SUITVariable}) format('woff2');
+            font-display: swap;              /* iOS에서 FOIT 방지 */
     }
 
     * {


### PR DESCRIPTION
## #️⃣연관된 이슈 
> #15 

## 📝작업 내용
일부 iOS 기기에서의 폰트 폴백 현상 해결 
제 로컬 맥북 기준 사파리와 크롬 브라우저에서 더블 체크했을 때 suit 폰트로 잘 나오는 것을 확인하였습니다. 

### 스크린샷 (선택)
<img width="923" height="733" alt="Screenshot 2025-10-08 at 5 45 15 pm" src="https://github.com/user-attachments/assets/fab73c23-06e0-49b9-9a01-edc007154a7e" />


### 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요