### PR TITLE
fix: 마이페이지 내 페이지 레이아웃 적용

### DIFF
--- a/src/assets/icons/TabBar.jsx
+++ b/src/assets/icons/TabBar.jsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { useNavigate, useLocation } from "react-router-dom";
+//import { useNavigate, useLocation } from "react-router-dom";
 import theme from "../../style/Theme.jsx";
 import HomeIcon from "../../assets/icons/HomeIcon.svg?react";
 import ScrapIcon from "../../assets/icons/Bookmark.svg?react";
@@ -17,12 +17,14 @@ export default function TabBar() {
 
   return (
     <NavBar>
-      {tabs.map(({ key, label, Icon }) => (
-        <NavItem key={key}>
-          <Icon width={24} height={24} />
-          <p>{label}</p>
-        </NavItem>
-      ))}
+      <BottomBar>
+        {tabs.map(({ key, label, Icon }) => (
+          <NavItem key={key}>
+            <Icon width={24} height={24} />
+            <p>{label}</p>
+          </NavItem>
+        ))}
+      </BottomBar>
     </NavBar>
   );
 }
@@ -61,4 +63,13 @@ const NavItem = styled.div`
   svg {
     fill: ${theme.colors.gray5};
   }
+`;
+
+const BottomBar = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(540px, 100vw);
+  z-index: 100;
 `;

--- a/src/components/Topbar.jsx
+++ b/src/components/Topbar.jsx
@@ -14,35 +14,45 @@ function Topbar({ title, icon }) {
     <Container>
       <ChevronLeft height={14} width={24} onClick={goBack} />
       <h3>{title}</h3>
-      {icon === "Link" && <Link height={18} width={24} />}
 
-      {icon === "none" && <div style={{ height: 18, width: 24 }} />}
+      {icon === "Link" ? (
+        <Link height={18} width={24} />
+      ) : (
+        // 오른쪽 공간 맞추기용 더미
+        <Spacer />
+      )}
     </Container>
   );
 }
 
 export default Topbar;
 
-//상단 고정
 const Container = styled.div`
-  width: 100%;
+  position: fixed;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(540px, 100vw); /* AppLayout 폭과 맞추기 */
   height: 46px;
   padding: 14px 15px;
   display: flex;
   justify-content: space-between;
   align-items: center;
   background-color: ${({ theme }) => theme.colors.white};
-
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 100;
+  z-index: 110; /* 탭바보다 살짝 위 */
+  /* 필요하면 그림자
+  box-shadow: 0 1px 0 rgba(0,0,0,0.05);
+  */
 
   h3 {
     color: ${({ theme }) => theme.colors.gray10};
     font-size: ${({ theme }) => theme.font.fontSize.headline20};
-    font-weight: ${({ theme }) => theme.font.lineHeight.bold};
+    font-weight: ${({ theme }) => theme.font.fontWeight.bold};
     line-height: ${({ theme }) => theme.font.lineHeight.normal};
   }
+`;
+
+const Spacer = styled.div`
+  width: 24px;
+  height: 18px;
 `;

--- a/src/components/buttons/BottomBtn.jsx
+++ b/src/components/buttons/BottomBtn.jsx
@@ -1,32 +1,50 @@
 import styled from "styled-components";
 
-function BottomBtn({ activated, text }) {
-  return <Btn activated={activated}>{text}</Btn>;
+function BottomBtn({ activated, text, onClick }) {
+  return (
+    <Bar>
+      <Btn
+        type="button"
+        activated={activated}
+        onClick={activated ? onClick : undefined}
+      >
+        {text}
+      </Btn>
+    </Bar>
+  );
 }
 
 export default BottomBtn;
 
-const Btn = styled.div`
-  width: calc(100% - 40px);
-  margin: 0 20px 40px 20px;
-  height: 50px;
-
+const Bar = styled.div`
   position: fixed;
   bottom: 0;
-  left: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(540px, 100vw); /* ✅ AppLayout 너비랑 맞추기 */
+  padding: 0 20px 40px; /* ✅ 기존 margin: 0 20px 40px 20px 대체 */
+  background: transparent;
+  z-index: 150;
+`;
+
+const Btn = styled.button`
+  width: 100%;
+  height: 50px;
+  border: none;
+  border-radius: 6px;
 
   display: flex;
   align-items: center;
   justify-content: center;
- 
+
   background-color: ${({ activated, theme }) =>
     activated ? theme?.colors?.Primary50 : theme?.colors?.gray4};
   color: ${({ activated, theme }) =>
     activated ? theme?.colors?.white : theme?.colors?.gray7};
+
   font-size: ${({ theme }) => theme.font.fontSize.label16};
   font-weight: ${({ theme }) => theme.font.fontWeight.semiBold};
 
-  border: none;
-  border-radius: 6px;
   cursor: ${({ activated }) => (activated ? "pointer" : "default")};
+  -webkit-tap-highlight-color: transparent;
 `;

--- a/src/components/layout/AppLayout.jsx
+++ b/src/components/layout/AppLayout.jsx
@@ -1,17 +1,11 @@
-// src/components/layout/AppLayout.jsx
-import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import TabBar from "../home/TabBar.jsx";
 
 export default function AppLayout({ children }) {
   return (
     <PageShell>
       <AppShell>
         <Inner>{children}</Inner>
-        <BottomBar>
-          <TabBar />
-        </BottomBar>
       </AppShell>
     </PageShell>
   );
@@ -42,14 +36,4 @@ const Inner = styled.main`
   max-width: min(540px, 100vw);
   margin: 0 auto;
   padding-bottom: 50px;
-`;
-
-/* 하단 탭바 공통 */
-const BottomBar = styled.div`
-  position: fixed;
-  bottom: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: min(540px, 100vw);
-  z-index: 100;
 `;

--- a/src/components/menu/HambugerMenu.jsx
+++ b/src/components/menu/HambugerMenu.jsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { createPortal } from "react-dom";
 import styled, { keyframes } from "styled-components";
 import theme from "../../style/Theme.jsx";
-import MenuBanner from "../../assets/icons/MenuBanner.png"; 
+import MenuBanner from "../../assets/icons/MenuBanner.png";
 
 export default function HamburgerMenu({ open, onClose }) {
   useEffect(() => {
@@ -33,9 +33,6 @@ export default function HamburgerMenu({ open, onClose }) {
 
         <MenuContainer>
           <MenuList>
-            <MenuItem as="a" href="/login">
-              로그인
-            </MenuItem>
             <MenuItem as="a" href="/mypage">
               마이페이지
             </MenuItem>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,6 +7,7 @@ import poster1 from "../assets/mock/poster1.jpg";
 import poster2 from "../assets/mock/poster2.jpg";
 import poster3 from "../assets/mock/poster3.jpg";
 import MenuTrigger from "../components/menu/MenuTrigger.jsx";
+import TabBar from "../components/home/TabBar.jsx";
 
 function TopTenItem({ rank, title, poster }) {
   return (
@@ -181,6 +182,7 @@ export default function Home() {
           </EventListWrapper>
         </EventWrapper>
       </Content>
+      <TabBar></TabBar>
     </Container>
   );
 }
@@ -362,11 +364,12 @@ const EventWrapper = styled.div`
 const CategoryWrapper = styled.div`
   display: flex;
   justify-content: center;
-  align-items: space-between;
   margin-bottom: 8px;
   z-index: 1;
+  width: 100%;
 `;
 const CategoryButton = styled.div`
+  flex: 1;  
   display: flex;
   width: 78px;
   padding: 6px 15px;
@@ -383,5 +386,5 @@ const CategoryButton = styled.div`
 const EventListWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  padding: 0px 20px;
+  padding: 0px 0px;
 `;

--- a/src/pages/Scrap.jsx
+++ b/src/pages/Scrap.jsx
@@ -2,6 +2,7 @@
 import styled from "styled-components";
 import Scraped from "../components/Scraped";
 import MenuTrigger from "../components/menu/MenuTrigger";
+import TabBar from "../components/home/TabBar";
 
 import poster1 from "../assets/mock/poster1.jpg";
 import poster2 from "../assets/mock/poster2.jpg";
@@ -60,6 +61,7 @@ function Scrap() {
           />
         ))}
       </Content>
+      <TabBar />
     </Container>
   );
 }

--- a/src/pages/guestBook/GuestBook.jsx
+++ b/src/pages/guestBook/GuestBook.jsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import { useState } from "react";
 
 import MenuTrigger from "../../components/menu/MenuTrigger";
+import TabBar from "../../components/home/TabBar";
 import Review from "./Review";
 import Cheering from "./Cheering";
 
@@ -33,6 +34,7 @@ function GuestBook() {
         {now === "review" && <Review />}
         {now === "cheering" && <Cheering />}
       </Content>
+      <TabBar />
     </Container>
   );
 }

--- a/src/pages/myPage/EnterCode.jsx
+++ b/src/pages/myPage/EnterCode.jsx
@@ -39,7 +39,7 @@ export default EnterCode;
 
 const Container = styled.div`
   width: 100%;
-  height: 100vh;
+  min-height: calc(100vh - 90px);
   padding-top: 46px;
 `;
 const Content = styled.div`

--- a/src/pages/myPage/MyPage.jsx
+++ b/src/pages/myPage/MyPage.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 
 import MypageHeader from "../../components/myPage/MypageHeader";
 import Banner from "../../components/myPage/Banner";
+import TabBar from "../../components/home/TabBar";
 
 import Kakao from "../../assets/icons/Kakao.png";
 import ChevronRight from "../../assets/icons/ChevronRight.svg?react";
@@ -154,6 +155,7 @@ function MyPage() {
           </TabList>
         </ListArea>
       </Content>
+      <TabBar />
     </Container>
   );
 }
@@ -278,7 +280,6 @@ const ShowList = styled.div`
     height: 130px;
     aspect-ratio: 46/65;
     border-radius: 3px;
- 
   }
   p {
     display: -webkit-box;


### PR DESCRIPTION
## #️⃣연관된 이슈 
> #이슈번호와 함께 적어주세요

## 📝작업 내용
마이페이지 내 페이지들에서도 피그마와 동일하게 구현될 수 있도록 아래사항 수정
- 하단바를 공통 레이아웃에서 제거 -> AppLayout에서는 제거하고 하단바 필요한 페이지에만 코드 삽입함
- 마이페이지 내 페이지에서 컴포넌트들(Topbar, BottomBtn) 스타일링을 일부 수정하여 공통 레이아웃 안에서 나올 수 있도록 수정 

### 스크린샷 (선택)
> 다른 팀원이 작업 결과물을 확인할 수 있도록 스크린샷을 첨부해주세요
<img width="841" height="702" alt="Screenshot 2025-11-01 at 8 42 28 pm" src="https://github.com/user-attachments/assets/2846de83-b869-490e-9953-82614bf67ccf" />

### 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요